### PR TITLE
Introduce v24 for ansible-lint

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -43,3 +43,14 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
+
+  # Maintain dependencies for ansible-lint v24
+  - package-ecosystem: pip
+    directory: "/requirements/v24"
+    schedule:
+      interval: daily
+    assignees:
+      - "haxorof"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ on:
 env:
   IMAGE_NAME: haxorof/ansible-lint
   LATEST_OS: alpine
-  LATEST_VERSION: v6
+  LATEST_VERSION: v24
 
 jobs:
   build_push:
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         os: [almalinux, alpine]
-        version: [v5, v6]
+        version: [v5, v6, v24]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/requirements/v24/requirements.txt
+++ b/requirements/v24/requirements.txt
@@ -1,0 +1,1 @@
+ansible-lint==v24.2.1

--- a/test/v24/main.yml
+++ b/test/v24/main.yml
@@ -1,0 +1,4 @@
+---
+- name: Test message
+  ansible.builtin.debug:
+    msg: test


### PR DESCRIPTION
Ansible-lint switched to a Major version based on the current year. This PR introduces v24 of ansible-lint. 